### PR TITLE
fix target dependency for parallel build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 # <dragorn> make is a twisted beast
 ##################################
 LDLIBS		= -lpcap
-CFLAGS		= -pipe -Wall -DOPENSSL 
+CFLAGS		= -pipe -Wall -DOPENSSL
 CFLAGS		+= -O2
 LDLIBS		+= -lcrypto
 CFLAGS		+= -g3 -ggdb
@@ -21,10 +21,10 @@ CC			= clang
 all: $(PROGOBJ) $(PROG)
 
 cowpatty: common.h md5.c md5.h sha1.h cowpatty.c cowpatty.h sha1.c \
-            sha1.h utils.c utils.h
+            sha1.h utils.c utils.h utils.o md5.o sha1.o
 	$(CC) $(CFLAGS) cowpatty.c -o cowpatty utils.o md5.o sha1.o $(LDLIBS)
 
-genpmk: genpmk.c cowpatty.h utils.h sha1.h common.h
+genpmk: genpmk.c cowpatty.h utils.h sha1.h common.h utils.o sha1.o
 	$(CC) $(CFLAGS) genpmk.c -o genpmk utils.o sha1.o $(LDLIBS)
 
 utils: utils.c utils.h


### PR DESCRIPTION
 As detected on Debian[0], builds with more than 4 jobs always fails
 because the dependencies of the targets cowpatty and genpmk are not
 well defined, this patch accomplish that and fixes the build on machines
 with more than 4 threads.

Thanks

 [0]https://tests.reproducible-builds.org/debian/rbuild/buster/amd64/cowpatty_4.8-1.rbuild.log.gz