### PR TITLE
[makefile] add -f to rm on clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ sha1: sha1.c sha1.h
 	$(CC) $(CFLAGS) sha1.c -c
 
 clean:
-	@rm $(PROGOBJ) $(PROG)
+	@rm -f $(PROGOBJ) $(PROG)
 
 strip:
 	@ls -l $(PROG)


### PR DESCRIPTION
This is based on a patch created by @rhertzog on Debian in order to fix the clean target.

@joswr1ght Could you please have a look at this and the other 2 PRs I opened? They should be enough for you to trigger a new release of cowpatty, since they fix important things.

Thanks